### PR TITLE
fixed ci syntax

### DIFF
--- a/CI-CD/GitLab/gitlab-maven.yml
+++ b/CI-CD/GitLab/gitlab-maven.yml
@@ -21,7 +21,7 @@ ws_scan:
   variables:
     WS_APIKEY: $API_KEY
     WS_USERKEY: $USER_KEY
-    WS_MAVEN_AGGREGATEMODULES: true
+    WS_MAVEN_AGGREGATEMODULES: "true"
     WS_WSS_URL: "https://saas.whitesourcesoftware.com/agent"
     WS_PRODUCTNAME: $CI_PROJECT_NAME
     WS_PROJECTNAME: $CI_COMMIT_REF_NAME


### PR DESCRIPTION
to avoid error "jobs:ws_scan:variables config should be a hash of key value pairs."