### PR TITLE
added support for project names with spaces

### DIFF
--- a/Scripts/Mend SCA/list-project-alerts.sh
+++ b/Scripts/Mend SCA/list-project-alerts.sh
@@ -46,7 +46,7 @@ if $showColors ; then
     NC="\e[0m"
 fi
 
-declare -a projects=( $(cat $PROJECT_DETAILS | jq -r '.projects[] | (.projectToken + "," + .projectName)') )
+declare -a "projects=( $(cat $PROJECT_DETAILS | jq -r '.projects[] | (.projectToken + "," + .projectName) | @sh') )"
 
 for project in "${projects[@]}"; do
     IFS=, read projectToken projectName <<< "$project"


### PR DESCRIPTION
Mend scan projects for docker images containing spaces between image name and tag name. This had not been supported in this script so far.