### PR TITLE
Fix API calls for check-project-state script

### DIFF
--- a/Mend CLI/github-action_sca_maven_scan
+++ b/Mend CLI/github-action_sca_maven_scan
@@ -13,6 +13,8 @@ jobs:
       MEND_URL: https://saas.mend.io
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
       # Downloading Mend CLI
       - name: Downloading Mend CLI
         run:  curl https://downloads.mend.io/production/unified/latest/linux_amd64/mend -o /usr/local/bin/mend && chmod +x /usr/local/bin/mend

--- a/Scripts/Mend SCA/check-project-state.sh
+++ b/Scripts/Mend SCA/check-project-state.sh
@@ -4,17 +4,18 @@
 # WS_GENERATEPROJECTDETAILSJSON: true
 # WS_USERKEY
 # WS_WSS_URL
+# WS_APIKEY
 
 WS_PROJECTTOKEN=$(jq -r '.projects | .[] | .projectToken' ./whitesource/scanProjectDetails.json)
 WS_URL=$(echo $WS_WSS_URL | awk -F "/agent" '{print $1}')
-
+REQUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d '{"requestType":"getProjectLastModification", "userKey": "'$WS_USERKEY'", "projectToken":"'$WS_PROJECTTOKEN'"}' $WS_URL/api/v1.3 | jq -r '.projectLastModifications[0].extraData.requestToken')
 IFS="|"
 scan_status=true
-pass_status=("UPDATE"${IFS}"FINISH"${IFS}"DIFF")
-fail_status=("UNKNOWN"${IFS}"FAIL")
+pass_status=("UPDATED"${IFS}"FINISHED")
+fail_status=("UNKNOWN"${IFS}"FAILED")
 while $scan_status
 do
-  new_status=$(curl -s -X POST -H "Content-Type: application/json" -d '{"requestType":"getProjectState", "userKey": "'$WS_USERKEY'", "projectToken":"'$WS_PROJECTTOKEN'"}' $WS_URL/api/v1.3 | jq '.projectState|.lastProcess' | tr -d '"')
+  new_status=$(curl -s -X POST -H "Content-Type: application/json" -d '{"requestType":"getRequestState", "userKey": "'$WS_USERKEY'", "orgToken":"'$WS_APIKEY'", "requestToken":"'$REQUEST_TOKEN'"}' $WS_URL/api/v1.3 | jq -r '.requestState')
   if [[ "${IFS}${pass_status[*]}${IFS}" =~ "${IFS}${new_status}${IFS}" ]];
   then
     scan_status=false


### PR DESCRIPTION
I think it is fixed now.
The script used a wrong API call in order to fetch the project state.
Now there are two calls:
1. getProjectLastModification - take the more recent update of a project and store its request token
2. getRequestState - with the request token above, query the state of the project.

The script will end with one of the following states:
SUCCESS="UPDATED" or "FINISHED"
FAILED="UNKNOWN" or "FAILED"

@tidharm , please review
@lukebrogan-mend - kindly test it as well