### PR TITLE
Fixed AzureDevOps-windows.yaml

### DIFF
--- a/CI-CD/AzureDevOps/Mend CLI/AzureDevOps-windows.yaml
+++ b/CI-CD/AzureDevOps/Mend CLI/AzureDevOps-windows.yaml
@@ -17,29 +17,30 @@ trigger:
 - main
 - release*
 
+pool:
+  vmImage: windows-latest
+
 steps:
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      script: |
-	### Build the application with your required package manager, e.g: ###
-    # - task: NodeTool@0
-    # - task: Maven@0
-    # - task: NuGetCommand@0
-    # - task: Gradle@0
-    # - task: PythonScript@0
-    ### Download the Mend Unified CLI ###
-    echo Downloading Mend CLI
-        Invoke-WebRequest -Uri "https://downloads.mend.io/cli/windows_amd64/mend.exe" -OutFile ".\mend.exe"
-		
-    ### Run SCA scan ###
-    echo Start Mend SCA scan
-    .\mend sca -u
-    
-    ### Run SAST scan ###
-    echo Start Mend SAST scan
-    .\mend sast --name=$(Build.Repository.Name)_$(Build.SourceBranchName) --app AZ$(System.TeamProject)_$(Build.Repository.Name)
-	
+- task: NodeTaskRunnerInstaller@0
+  inputs:
+    nodeVersion: '6'
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      ### Build the tool
+      echo "Building the application"
+      npm install --ignore-scripts
+      ### Download the Mend Unified CLI ###
+      echo "Downloading Mend CLI"
+      Invoke-WebRequest -Uri "https://downloads.mend.io/cli/windows_amd64/mend.exe" -OutFile "mend.exe"
+      ### Run SCA scan ###
+      echo "Start Mend SCA scan"
+      ./mend.exe sca -u
+      ### Run SAST scan ###
+      echo "Start Mend SAST scan"
+      ./mend.exe sast --name=$(Build.Repository.Name)_$(Build.SourceBranchName) --app AZ$(System.TeamProject)_$(Build.Repository.Name)
+
   env:
     ### SCA and Container Environment Variables ###
     MEND_URL: $(MEND_SCA_URL)


### PR DESCRIPTION
AzureDevOps-windows.yaml had some formatting issues. Fixed those errors and added a step to build the project before scanning. This should now work out of the box after uncommenting the appropriate sections.