### PR TITLE
Updated PIP No Host Rules solution to add a clarification for 'hostType'

### DIFF
--- a/Repo-Integration/Private-Registries-No-HostRules/PIP/config.js
+++ b/Repo-Integration/Private-Registries-No-HostRules/PIP/config.js
@@ -5,6 +5,7 @@ module.exports = {
 	}],
 	"hostRules": [
 		{
+			"hostType": "pypi",
 			"matchHost": process.env.PIP_REGISTRY,
 			"username": process.env.PIP_USER,
 			"password": process.env.PIP_PASS

--- a/Repo-Integration/Private-Registries-No-HostRules/PIP/docker-compose.yml
+++ b/Repo-Integration/Private-Registries-No-HostRules/PIP/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     restart: always
     extra_hosts:
       - "files.pythonhosted.org:127.0.0.1"
+      - "pypi.org:127.0.0.1"
     logging:
       driver: local
       options:
@@ -49,6 +50,7 @@ services:
     container_name: wss-scanner-ghe
     extra_hosts:
       - "files.pythonhosted.org:127.0.0.1"
+      - "pypi.org:127.0.0.1"
     environment:
       WS_UA_LOG_IN_CONSOLE: true
       LOG_LEVEL: DEBUG


### PR DESCRIPTION
PIP host rule functionality needs a clarification of the hostType in the hostRules for config.js. This was updated as well as extra_hosts to include: "pypi.org" being blocked.