### PR TITLE
update renovate presets

### DIFF
--- a/Repo-Integration/configs/README.md
+++ b/Repo-Integration/configs/README.md
@@ -16,8 +16,8 @@ In all .whitesource file update examples, you should replace the inherited organ
     },
     "enableRenovate": true,
     "extends": [
-       "config:base",
-       "github>whitesource/merge-confidence:beta",
+       "config:recommended",
+       "mergeConfidence:all-badges",
        "github>mend-toolkit/mend-examples//Repo-Integration/Renovate/smart-merge"
       ]
   }


### PR DESCRIPTION
Following the update to Renovate v37, this PR will update our examples with the new presets
https://docs.renovatebot.com/presets-config/#configrecommended
https://docs.renovatebot.com/presets-mergeConfidence/#mergeconfidenceall-badges