### PR TITLE
Fix CA certs path for controller

### DIFF
--- a/Repo-Integration/Self-Managed/certs.md
+++ b/Repo-Integration/Self-Managed/certs.md
@@ -33,8 +33,8 @@ Example docker-compose.yaml snippet:
     volumes:
       # handles certs for most system utilities and git
       - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt
-      # containerbase java install symlinks /opt/buildpack/ssl/cacerts into the jre security folder
-      - /etc/pki/ca-trust/extracted/java/cacerts:/opt/buildpack/ssl/cacerts
+      # containerbase java install symlinks /opt/containerbase/ssl/cacerts into the jre security folder
+      - /etc/pki/ca-trust/extracted/java/cacerts:/opt/containerbase/ssl/cacerts
     # ...
 ```
 
@@ -82,8 +82,8 @@ Example docker-compose.yaml snippet:
     volumes:
       # handles certs for most system utilities and git
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt
-      # containerbase java install symlinks /opt/buildpack/ssl/cacerts into the jre security folder
-      - /etc/ssl/java/cacerts:/opt/buildpack/ssl/cacerts
+      # containerbase java install symlinks /opt/containerbase/ssl/cacerts into the jre security folder
+      - /etc/ssl/java/cacerts:/opt/containerbase/ssl/cacerts
     # ...
 ```
 


### PR DESCRIPTION
Correcting CA certs path to /opt/containerbase/ssl/cacerts for controller service in docker-compose.yml snippets