### PR TITLE
Updated setup.sh script to fix env_check and port_check functions

### DIFF
--- a/Repo-Integration/Self-Managed/setup.sh
+++ b/Repo-Integration/Self-Managed/setup.sh
@@ -153,6 +153,7 @@ if [[ $DOCKER_COMPOSE_VERSION -ge 2 ]]; then
     echo "Docker Compose version is greater than or equal to 2."
 else
     echo "Docker Compose version is less than 2.  Please install docker compose by following the README"
+    exit 1
 fi
 
 }

--- a/Repo-Integration/Self-Managed/setup.sh
+++ b/Repo-Integration/Self-Managed/setup.sh
@@ -161,32 +161,6 @@ fi
 function port_check(){
 
 echo -e "\nChecking all required ports are available"
-echo "Checking internally avaialble ports"
-# Test that internal ports are available for use
-INTERNAL_PORTS=(8582 9393)
-
-for PORT in "${INTERNAL_PORTS[@]}"; do
-
-  # Start listener on port in the background, storing the process ID
-  echo "Listening on: $PORT"
-  nc -lp $PORT &
-
-  # Check for connection success
-  echo "Testing connection to: 127.0.0.1:$PORT"
-  nc -z 127.0.0.1 $PORT
-
-  # Store the connection check result
-  CONNECTION_RESULT=$?
-  if [[ $CONNECTION_RESULT -ne 0 ]]; then
-    echo "Connection Failed. Exiting..."
-    exit 1
-  else
-    echo "Connection Result: Success"
-  fi
-done
-
-echo  "Checking externally available ports"
-
 # Get public IP address
 PUBLIC_IP=$(curl -s http://checkip.amazonaws.com)
 


### PR DESCRIPTION
Fixes some issues with the following functions:
env_check: Did not check for docker version and docker compose version properly, and therefore returned errors. Also it did not error out if the wrong versions were found

port_check: Tests all ports that the containers expose, even if they should only be internally accessible. Removed internal only ports.