### PR TITLE
Fix dotnet restore command with --use-lock-file option

### DIFF
--- a/CI-CD/AzureDevOps/Mend CLI/AzureDevOps-advanced-linux.yml
+++ b/CI-CD/AzureDevOps/Mend CLI/AzureDevOps-advanced-linux.yml
@@ -43,7 +43,7 @@ jobs:
     - script: |
         SLN=$(find ./ -type f -wholename "*.sln" | head -n 1)
         echo "${SLN} is the solution that will be built"
-        dotnet restore ${SLN}  --use-lockfile
+        dotnet restore ${SLN}  --use-lock-file
       displayName: 'dotnet build'
 ### The mend dep scan should be called AFTER a package manager build step such as "mvn clean install -DskipTests=true" or "npm install --only=prod"
     - script: |
@@ -120,7 +120,7 @@ jobs:
     - script: |
         SLN=$(find ./ -type f -wholename "*.sln" | head -n 1)
         echo "${SLN} is the solution that will be built"
-        dotnet restore ${SLN} --use-lockfile
+        dotnet restore ${SLN} --use-lock-file
       displayName: 'dotnet build'
 ### Build the image ###
     - script: |
@@ -227,7 +227,7 @@ jobs:
     - script: |
         SLN=$(find ./ -type f -wholename "*.sln" | head -n 1)
         echo "${SLN} is the solution that will be built"
-        dotnet restore ${SLN} --use-lockfile
+        dotnet restore ${SLN} --use-lock-file
       displayName: 'dotnet build'
 ### The mend dep scan should be called AFTER a package manager build step such as "mvn clean install -DskipTests=true" or "npm install --only=prod"
     - script: |


### PR DESCRIPTION
ubuntu@ip-1-2-3-4:~$ dotnet restore project.sln --use-lockfile
MSBUILD : error MSB1001: Unknown switch.
    Full command line: '/usr/lib/dotnet/sdk/8.0.105/MSBuild.dll -maxcpucount -verbosity:m -nologo -target:Restore project.sln --use-lockfile'
  Switches appended by response files:
Switch: --use-lockfile

For switch syntax, type "MSBuild -help"


ubuntu@ip-1-2-3-4:~$ dotnet restore -h 
Description:
  .NET dependency restorer

Usage:
  dotnet restore [<PROJECT | SOLUTION>...] [options]

Arguments:
  <PROJECT | SOLUTION>  The project or solution file to operate on. If a file is not specified, the command 
                        will search the current directory for one.

Options:
.
.
.
  **--use-lock-file                     Enables project lock file to be generated and used with restore.**
