### PR TITLE
Remove exit code checks on Jenkins

### DIFF
--- a/CI-CD/Jenkins/Mend CLI/vars/MendSASTScan.groovy
+++ b/CI-CD/Jenkins/Mend CLI/vars/MendSASTScan.groovy
@@ -5,11 +5,6 @@ def call() {
       export repo=$(basename -s .git $(git config --get remote.origin.url))
       export branch=$(git rev-parse --abbrev-ref HEAD)
       ./mend code --non-interactive -s "*//${JOB_NAME}//${repo}_${branch}" -r --formats sarif --filename code-results
-      if [[ "$code_exit" == "9" ]]; then
-        echo "[warning] Code scan threshold violation"
-      else
-        echo "No policy violations found in code scan"
-      fi
       '''
    archiveArtifacts artifacts: "code-results.sarif", fingerprint: true
  }

--- a/CI-CD/Jenkins/Mend CLI/vars/MendSCAScan.groovy
+++ b/CI-CD/Jenkins/Mend CLI/vars/MendSCAScan.groovy
@@ -8,15 +8,7 @@ def call(Map args = [:]) {
         sh """
         export repo=\$(basename -s .git \$(git config --get remote.origin.url))
         export branch=\$(git rev-parse --abbrev-ref HEAD)
-
         ./mend dep -u ${reachabilityFlag} -s "*//\${JOB_NAME}//\${repo}_\${branch}" --fail-policy --non-interactive --export-results dep-results.txt
-        
-        dep_exit=\$?
-        if [[ "\$dep_exit" == "9" ]]; then
-            echo "[warning] Dependency scan policy violation"
-        else
-            echo "No policy violations found in dependencies scan"
-        fi
         """
     }
     archiveArtifacts artifacts: "dep-results.txt", fingerprint: true


### PR DESCRIPTION
Removing the exit code checks for SCA and SAST as CLI prints them regadless:
SCA: `Error: Scan ended with Exit Code [9] due to policy and workflow condition violations.`
SAST: `Warning: Scan exited with return code 9`